### PR TITLE
No need to clear the buffer after a Wire.requestFrom.

### DIFF
--- a/software/TSL45315.ino
+++ b/software/TSL45315.ino
@@ -68,7 +68,6 @@ void loop()
   Wire.requestFrom(I2C_ADDR, 2); //request 2 bytes
   l = Wire.read();
   h = Wire.read();
-  while(Wire.available()){ Wire.read(); } //received more bytes?
   lux  = (h<<8) | (l<<0);
   lux *= 1; //M=1
   // lux *= 2; //M=2


### PR DESCRIPTION
Explanation: https://github.com/Koepel/How-to-use-the-Arduino-Wire-library/wiki/Common-mistakes#4
Beside that, when the Master call Wire.requestFrom to requests 2 bytes, then it is impossible that it will have more than two bytes.